### PR TITLE
Fix bodyAppearedEvent handling for Govee Water Leak Sensors

### DIFF
--- a/Govee/v2/Mavrrick.Govee_Cloud_MQTT.groovy
+++ b/Govee/v2/Mavrrick.Govee_Cloud_MQTT.groovy
@@ -138,17 +138,29 @@ def mqttPost(String instance, String state){
             sendEvent(name: instance, value: time, displayed: true)
     } 
     else if (instance == 'bodyAppearedEvent') {
-        if (state == "Presence") {
-            if (descLog) { log.info "mqttPost(): bodyAppearedEvent Present found"}
-            sendEvent(name: "presence", value: "present", displayed: true)
-            sendEvent(name: "motion", value: "active", displayed: true)
-        } else if (state == "Absence") {
-            if (descLog) { log.info "mqttPost(): bodyAppearedEvent Not Present found"}
-            sendEvent(name: "presence", value: "not present", displayed: true)
-            sendEvent(name: "motion", value: "inactive", displayed: true)            
+            String stateStr = ""
+            if (state instanceof List && !state.isEmpty()) {
+                stateStr = state[0]?.message?.toString() ?: state.toString()
+            } else {
+                stateStr = state.toString()
+            }
+            
+            if (debugLog) log.debug "mqttPost(): Evaluated bodyAppearedEvent state target text: ${stateStr}"
+
+            // Match "Leaked" or value:1
+            if (stateStr.equalsIgnoreCase("Presence") || stateStr.equalsIgnoreCase("Leaked") || stateStr.contains("value:1")) {
+                if (descLog) { log.info "mqttPost(): bodyAppearedEvent Active/Leak state matched."}
+                sendEvent(name: "presence", value: "present", isStateChange: true, displayed: true)
+                sendEvent(name: "motion", value: "active", isStateChange: true, displayed: true)
+            
+            // Match "Clear", "Absence", or value:0
+            } else if (stateStr.equalsIgnoreCase("Absence") || stateStr.equalsIgnoreCase("Clear") || stateStr.contains("cleared") || stateStr.contains("value:0")) {
+                if (descLog) { log.info "mqttPost(): bodyAppearedEvent Inactive/Clear state matched."}
+                sendEvent(name: "presence", value: "not present", isStateChange: true, displayed: true)
+                sendEvent(name: "motion", value: "inactive", isStateChange: true, displayed: true)            
+            }
         }
     }
-}
 
 
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The current MQTT library parsing logic for bodyAppearedEvent assumes state will arrive strictly as a string text ("Presence" / "Absence"). However, Govee's API documentation and live payloads for hardware like the H5054 Water Leak Sensor transmit state as a nested array of maps (e.g., [[message:Leaked, value:1]] and [[message:Clear, value:0]]).
This PR adds a type-safety check using instanceof List to safely extract strings out of both raw string states (for mmWave motion sensors) and nested map lists (for water leak sensors). It also maps the "Clear" and value:0 states to properly reset attributes back to inactive on the Hubitat event bus.